### PR TITLE
variables.styl and mixins.styl were imported three times

### DIFF
--- a/source/static/styles/main.styl
+++ b/source/static/styles/main.styl
@@ -2,6 +2,8 @@
 @import "_variables" // Project variables
 @import "core/mixins" // System mixins
 @import "_mixins" // Project mixins
+@import "core/typography"
+@import "core/helpers"
 
 // Svg icons
 @import "../../../tmp/icons-template.styl" if file-exists("../../../tmp/icons-template.styl")

--- a/source/static/styles/reset.styl
+++ b/source/static/styles/reset.styl
@@ -3,7 +3,7 @@
 @import "core/mixins" // System mixins
 @import "_mixins" // Project mixins
 @import "core/reset"
-@import "normalize.css/normalize.css" // install from node_modules
+@import "../../modules/normalize.css/normalize.css" // install from node_modules
 @import "core/typography"
 @import "core/helpers"
 // @import '_fonts'

--- a/source/static/styles/reset.styl
+++ b/source/static/styles/reset.styl
@@ -1,11 +1,5 @@
-@import "core/variables" // System variables
-@import "_variables" // Project variables
-@import "core/mixins" // System mixins
-@import "_mixins" // Project mixins
 @import "core/reset"
-@import "../../modules/normalize.css/normalize.css" // install from node_modules
-@import "core/typography"
-@import "core/helpers"
+@import "normalize.css/normalize.css" // install from node_modules
 // @import '_fonts'
 @import url("https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&subset=cyrillic")
 @import "core/print"

--- a/tools/removeDemo/pages/index.pug
+++ b/tools/removeDemo/pages/index.pug
@@ -7,10 +7,6 @@ block head
 
 	style
 		:stylus
-			@import "../static/styles/core/variables.styl"
-			@import "../static/styles/_variables.styl"
-			@import "../static/styles/core/mixins.styl"
-			@import "../static/styles/_mixins.styl"
 			@import "../modules/_page-list/_page-list.styl"
 
 block page


### PR DESCRIPTION
### Description

When ready to develop I found that the stylus files were included multiple times.

The change I made to the link where normalize.css file is, didn't work. 
So I changed back to how it was.
I don't know yet if it is working correctly as it was. I didn't find the normalize.css where the reset.styl is.
But no error was reported. So I don't know if there is a process at compilation time that moves it or something.

### Motivation and Context

I think that:
- it is best that reset.styl  should include only reset, normalize and a base font
- everything else should go in mail.styl

There is no need to include @import variables.styl  given that the stylesheets were already included in the pug's head mixin.

### How Has This Been Tested?
I ran $npm start on both the demo and also after clean.
Worked ok.

### Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
None of the above

## Checklist:
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
